### PR TITLE
Some refactoring

### DIFF
--- a/src/sorting_algorithms/bubble_sort.clj
+++ b/src/sorting_algorithms/bubble_sort.clj
@@ -7,9 +7,9 @@
   [vals]
   (-> (fn [sorted-vals next-val]
         (cond
-         (empty? sorted-vals) [next-val]
+         (empty? sorted-vals)            [next-val]
          (> next-val (peek sorted-vals)) (conj sorted-vals next-val)
-         :else (conj (pop sorted-vals) next-val (peek sorted-vals))))
+         :else                           (conj (pop sorted-vals) next-val (peek sorted-vals))))
       (reduce [] vals)))
 
 (defn rearrange

--- a/src/sorting_algorithms/bubble_sort.clj
+++ b/src/sorting_algorithms/bubble_sort.clj
@@ -5,11 +5,11 @@
 (defn bubblify
   "Bubbles the given values."
   [vals]
-  (-> (fn [sorted-vals next-val]
+  (-> (fn [bubble-vals next-val]
         (cond
-         (empty? sorted-vals)            [next-val]
-         (> next-val (peek sorted-vals)) (conj sorted-vals next-val)
-         :else                           (conj (pop sorted-vals) next-val (peek sorted-vals))))
+         (empty? bubble-vals)            [next-val]
+         (> next-val (peek bubble-vals)) (conj bubble-vals next-val)
+         :else                           (conj (pop bubble-vals) next-val (peek bubble-vals))))
       (reduce [] vals)))
 
 (defn rearrange

--- a/src/sorting_algorithms/insertion_sort.clj
+++ b/src/sorting_algorithms/insertion_sort.clj
@@ -7,11 +7,11 @@
   [sorted-values value]
   (if (empty? sorted-values)
     [value]
-    (let [not-last-sorted-vals (pop sorted-values)
-          last-val (peek sorted-values)]
-        (if (>= value last-val)
+    (let [last-val (peek sorted-values)]
+      (if (>= value last-val)
         (conj sorted-values value)
-        (conj (insert-at-right-place not-last-sorted-vals value) last-val)))))
+        (let [not-last-sorted-vals (pop sorted-values)]
+          (conj (insert-at-right-place not-last-sorted-vals value) last-val))))))
 
 (defn sort
   "Sorts using the insertion sort algorithm.

--- a/src/sorting_algorithms/insertion_sort.clj
+++ b/src/sorting_algorithms/insertion_sort.clj
@@ -10,8 +10,10 @@
     (let [last-val (peek sorted-values)]
       (if (>= value last-val)
         (conj sorted-values value)
-        (let [not-last-sorted-vals (pop sorted-values)]
-          (conj (insert-at-right-place not-last-sorted-vals value) last-val))))))
+        (-> sorted-values
+            pop                           ;; compute rest of unsorted values
+            (insert-at-right-place value)
+            (conj last-val))))))
 
 (defn sort
   "Sorts using the insertion sort algorithm.

--- a/src/sorting_algorithms/merge_sort.clj
+++ b/src/sorting_algorithms/merge_sort.clj
@@ -8,14 +8,12 @@
 
 (defn merge-sort
   "Merges and sorts two arrays already sorted."
-  [vals1 vals2]
-  (let [head1 (first vals1)
-        head2 (first vals2)]
-    (cond
-     (empty? vals1) vals2
-     (empty? vals2) vals1
-     (< head1 head2) (cons head1 (merge-sort (drop 1 vals1) vals2))
-     :else (cons head2 (merge-sort vals1 (drop 1 vals2))))))
+  [[head1 & rest1 :as vals1] [head2 & rest2 :as vals2]]
+  (cond
+    (empty? vals1)  vals2
+    (empty? vals2)  vals1
+    (< head1 head2) (cons head1 (merge-sort rest1 vals2))
+    :else           (cons head2 (merge-sort vals1 rest2))))
 
 (defn process
   [vals]

--- a/src/sorting_algorithms/merge_sort.clj
+++ b/src/sorting_algorithms/merge_sort.clj
@@ -2,7 +2,7 @@
   "Sorting using merge sort algorithm.")
 
 (defn explode
-  "Explodes an vecotr with one or many values into multiples single value vectors."
+  "Explodes a vector with one or many values into multiples single value vectors."
   [vals]
   (for [i vals] [i]))
 

--- a/src/sorting_algorithms/merge_sort.clj
+++ b/src/sorting_algorithms/merge_sort.clj
@@ -21,10 +21,10 @@
   [vals]
   (if (empty? (rest vals))
     (first vals)
-    (->>  vals
-          (partition 2 2 [])
-          (map #(merge-sort (first %) (second %)))
-          process)))
+    (->> vals
+         (partition 2 2 [])
+         (map #(merge-sort (first %) (second %)))
+         process)))
 
 (defn sort
   "Sorts using the merge sort algorithm.

--- a/src/sorting_algorithms/quick_sort.clj
+++ b/src/sorting_algorithms/quick_sort.clj
@@ -1,6 +1,5 @@
 (ns sorting-algorithms.quick-sort
-  "Sorting using the quick sort algorithm."
-  (:require [sorting-algorithms.utils :refer [remove-val]]))
+  "Sorting using the quick sort algorithm.")
 
 
 (defn sort
@@ -10,11 +9,9 @@
   [2 1] 3 [4  5]
   [1] 2 3  4 [5]
    1  2  3  4  5"
-  [values]
+  [[head & tail :as values]]
   (if (empty? values)
     []
-    (let [head           (first values)
-          remaining-vals (remove-val head values)
-          greaters       (filter #(>  % head) remaining-vals)
-          smallers       (filter #(<= % head) remaining-vals)]
+    (let [greaters (filter #(>  % head) tail)
+          smallers (filter #(<= % head) tail)]
       (concat (sort smallers) [head] (sort greaters)))))

--- a/src/sorting_algorithms/selection_sort.clj
+++ b/src/sorting_algorithms/selection_sort.clj
@@ -13,9 +13,9 @@
   "Sorts values using the selection sort algorithm.
   Steps:
   |---------------+-----------------|
-  | ordered vals  | unordered vals  |
+  | sorted vals   | unsorted vals   |
   |---------------+-----------------|
-  | [ ]           | [1  4  2  3 ]   |
+  | [ ]           | [4  2  1  3 ]   |
   | [1 ]          | [4  2  3 ]      |
   | [1  2 ]       | [4  3 ]         |
   | [1  2  3 ]    | [4 ]            |

--- a/src/sorting_algorithms/utils.clj
+++ b/src/sorting_algorithms/utils.clj
@@ -5,6 +5,7 @@
 (defn remove-val
   "Removes the first given item from the vector."
   [n ns]
-  (->> (take-while #(not= % n) ns)
-       (merge (rest (drop-while #(not= % n) ns)))
-       flatten))
+  (let [not=n? #(not= % n)]
+    (->> (take-while not=n? ns)
+         (merge (rest (drop-while not=n? ns)))
+         flatten)))

--- a/src/sorting_algorithms/utils.clj
+++ b/src/sorting_algorithms/utils.clj
@@ -6,6 +6,5 @@
   "Removes the first given item from the vector."
   [n ns]
   (let [not=n? #(not= % n)]
-    (->> (take-while not=n? ns)
-         (merge (rest (drop-while not=n? ns)))
-         flatten)))
+    (-> (take-while not=n? ns)
+        (concat (rest (drop-while not=n? ns))))))

--- a/src/sorting_algorithms/utils.clj
+++ b/src/sorting_algorithms/utils.clj
@@ -5,6 +5,6 @@
 (defn remove-val
   "Removes the first given item from the vector."
   [n ns]
-  (->> (take-while #(not= % n ) ns)
+  (->> (take-while #(not= % n) ns)
        (merge (rest (drop-while #(not= % n) ns)))
-       (flatten)))
+       flatten))

--- a/src/sorting_algorithms/utils.clj
+++ b/src/sorting_algorithms/utils.clj
@@ -5,6 +5,5 @@
 (defn remove-val
   "Removes the first given item from the vector."
   [n ns]
-  (let [not=n? #(not= % n)]
-    (-> (take-while not=n? ns)
-        (concat (rest (drop-while not=n? ns))))))
+  (let [[heads tails] (split-with #(not= % n) ns)]
+    (concat heads (rest tails))))


### PR DESCRIPTION
Tests still ok:

``` sh
\[\][nix-shell:~/repo/perso/clj-sorting-algorithms]$\[\] lein test
WARNING: sort already refers to: #'clojure.core/sort in namespace: sorting-algorithms.bubble-sort, being replaced by: #'sorting-algorithms.bubble-sort/sort
WARNING: sort already refers to: #'clojure.core/sort in namespace: sorting-algorithms.bubble-sort-test, being replaced by: #'sorting-algorithms.bubble-sort/sort
WARNING: sort already refers to: #'clojure.core/sort in namespace: sorting-algorithms.insertion-sort, being replaced by: #'sorting-algorithms.insertion-sort/sort
WARNING: sort already refers to: #'clojure.core/sort in namespace: sorting-algorithms.insertion-sort-test, being replaced by: #'sorting-algorithms.insertion-sort/sort
WARNING: sort already refers to: #'clojure.core/sort in namespace: sorting-algorithms.merge-sort, being replaced by: #'sorting-algorithms.merge-sort/sort
WARNING: sort already refers to: #'clojure.core/sort in namespace: sorting-algorithms.merge-sort-test, being replaced by: #'sorting-algorithms.merge-sort/sort
WARNING: sort already refers to: #'clojure.core/sort in namespace: sorting-algorithms.quick-sort, being replaced by: #'sorting-algorithms.quick-sort/sort
WARNING: sort already refers to: #'clojure.core/sort in namespace: sorting-algorithms.quick-sort-test, being replaced by: #'sorting-algorithms.quick-sort/sort
WARNING: sort already refers to: #'clojure.core/sort in namespace: sorting-algorithms.selection-sort, being replaced by: #'sorting-algorithms.selection-sort/sort
WARNING: sort already refers to: #'clojure.core/sort in namespace: sorting-algorithms.selection-sort-test, being replaced by: #'sorting-algorithms.selection-sort/sort
WARNING: sort already refers to: #'clojure.core/sort in namespace: sorting-algorithms.shell-sort, being replaced by: #'sorting-algorithms.shell-sort/sort
WARNING: sort already refers to: #'clojure.core/sort in namespace: sorting-algorithms.shell-sort-test, being replaced by: #'sorting-algorithms.shell-sort/sort

lein test sorting-algorithms.bubble-sort-test
{:test-var "testing-bubble-sort", :result true, :num-tests 1000, :seed 1426614276771}

lein test sorting-algorithms.insertion-sort-test
{:test-var "testing-insertion-sort", :result true, :num-tests 1000, :seed 1426614277879}

lein test sorting-algorithms.merge-sort-test
{:test-var "testing-merge-sort", :result true, :num-tests 1000, :seed 1426614278193}

lein test sorting-algorithms.quick-sort-test
{:test-var "testing-quick-sort", :result true, :num-tests 1000, :seed 1426614278616}

lein test sorting-algorithms.selection-sort-test
{:test-var "testing-selection-sort", :result true, :num-tests 1000, :seed 1426614278926}

lein test sorting-algorithms.shell-sort-test
{:test-var "testing-shell-sort", :result true, :num-tests 1000, :seed 1426614279540}

lein test sorting-algorithms.test-utils

Ran 6 tests containing 6 assertions.
0 failures, 0 errors.
```
